### PR TITLE
Use iframe and viewport relative units

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,8 +33,8 @@ line {
 <body>
 
   <div id = "main_window">
-    <embed src = "RomieBanerjee-CV.pdf"
- type="application/pdf">
+    <iframe src = "RomieBanerjee-CV.pdf"
+ type="application/pdf" style="width:95vw;height:95vh;">
    
   
   </div>


### PR DESCRIPTION
You may want to test this in some different browsers on different OSes, but the unitless version you have now results in a tiny window about 300x100 pixels on the computers in my house.